### PR TITLE
Remove Fireblocks references and strengthen MetaMask/TXTX requirements

### DIFF
--- a/docs/avs/operator-onboarding/mainnet-preparation.md
+++ b/docs/avs/operator-onboarding/mainnet-preparation.md
@@ -63,7 +63,9 @@ Before starting Step 1 registration, configure the DIN app for mainnet:
 ## Wallet setup options
 
 :::warning MetaMask Required for TXTX Onboarding
-**You must use MetaMask wallet when connecting to the DIN app for AVS onboarding.** TXTX is only proven to work reliably with MetaMask, and we strongly recommend operators use MetaMask for their onboarding TXTX wallet interface. While you can store your keys in a hardware wallet, you must access them through MetaMask during the onboarding process. Onboarding will fail if you use other wallet connection methods (WalletConnect, Coinbase Wallet, etc.).
+**You must use MetaMask wallet when connecting to the DIN app for AVS onboarding.** TXTX is only proven to work reliably with MetaMask, and we strongly recommend
+operators use MetaMask for their onboarding TXTX wallet interface. While you can store your keys in a hardware wallet, you must access them through MetaMask
+during the onboarding process. Onboarding will fail if you use other wallet connection methods (WalletConnect, Coinbase Wallet, etc.).
 :::
 
 Use one of the following wallet options:
@@ -74,7 +76,7 @@ Use one of the following wallet options:
   - Create new derivation path
   - Document recovery phrase securely
 
-- **Option 2: Software wallet (not recommended)**
+- **Option 2: Software wallet**
 
   - Higher risk profile
   - Use only if hardware unavailable

--- a/docs/avs/operator-onboarding/prerequisites.md
+++ b/docs/avs/operator-onboarding/prerequisites.md
@@ -9,10 +9,12 @@ Before starting the [onboarding process](./onboard/) using the [DIN app](https:/
 ## Wallet requirements
 
 :::warning TXTX Only Works with MetaMask
-**TXTX is only proven to work reliably with MetaMask.** We strongly recommend operators use MetaMask for their onboarding TXTX wallet interface. Other wallet connection methods (WalletConnect, Coinbase Wallet, etc.) will cause TXTX onboarding to fail.
+**TXTX is only proven to work reliably with MetaMask.** We strongly recommend operators use MetaMask for their onboarding TXTX wallet interface. Other wallet
+connection methods (WalletConnect, Coinbase Wallet, etc.) will cause TXTX onboarding to fail.
 :::
 
-DIN supports [multiple wallet setup options](./mainnet-preparation.md#wallet-setup-options) for storing your keys (hardware wallets, software wallets), but you must connect through MetaMask when using TXTX for onboarding.
+DIN supports [multiple wallet setup options](./mainnet-preparation.md#wallet-setup-options) for storing your keys (hardware wallets, software wallets), but you
+must connect through MetaMask when using TXTX for onboarding.
 
 ### Mainnet
 


### PR DESCRIPTION
TXTX is only proven to work reliably with MetaMask. Updated operator onboarding documentation to:

- Remove all Fireblocks setup instructions from mainnet preparation
- Remove Fireblocks wallet option from wallet setup options
- Strengthen MetaMask requirements with clear warnings about TXTX
- Emphasize that TXTX only works with MetaMask wallet interface
- Update fatal mistakes and costly errors sections
