### PR TITLE
Updates to roadmap because DIN as an AVS has launched

### DIFF
--- a/docs/avs/operator-onboarding/mainnet-preparation.md
+++ b/docs/avs/operator-onboarding/mainnet-preparation.md
@@ -1,22 +1,24 @@
 ---
-description: Instructions for preparing for mainnet
+description: Instructions for onboarding to mainnet
 ---
 
-# Prepare for mainnet
+# Onboard to mainnet
+
+DIN launched its mainnet AVS on November 17, 2025. Follow this guide to onboard as a mainnet operator.
 
 :::warning 17-day activation period
 Onboarding an operator on mainnet involves a 17-day activation period.
-Ensure you create and register TWO wallets (primary + backup) with EigenLayer,
-so if your primary wallet encounters issues during onboarding, you won't waste the 17-day period.
+Create and register TWO wallets (primary + backup) with EigenLayer.
+If your primary wallet encounters issues during onboarding, the backup wallet prevents wasting the 17-day period.
 :::
 
 :::info Video tutorial
-[Watch the mainnet preparation tutorial.](https://www.loom.com/share/db796cf0b89b40b0961595f961cb1672?sid=daf8a0db-1325-444e-95b1-aeb166f1c635)
+[Watch the mainnet onboarding tutorial.](https://www.loom.com/share/db796cf0b89b40b0961595f961cb1672?sid=daf8a0db-1325-444e-95b1-aeb166f1c635)
 :::
 
 ## Initial action items
 
-Perform the following steps as soon as possible:
+Complete the following steps to begin onboarding:
 
 1. **Create TWO new wallets (primary + backup):**
     - Generate **two** new externally owned account wallets. Refer to the
@@ -31,16 +33,16 @@ Perform the following steps as soon as possible:
    - Minimum 1 ETH per wallet (EigenLayer recommendation).
    - Transfer to both operator wallets.
 
-   Specific stake amounts will be calculated during [Step 2](./onboard/stake-tokens.md).
+   Specific stake amounts are calculated during [Step 2](./onboard/stake-tokens.md).
 
 3. **Register BOTH wallets with EigenLayer:**
    - Access the [DIN app](https://app.din.build).
-   - Complete only [Step 1](./onboard/register-operator.md) with your **primary wallet**.
-   - Complete only [Step 1](./onboard/register-operator.md) again with your **backup wallet**.
-   - This ensures both wallets will be ready by mainnet launch in case you need to switch.
+   - Complete [Step 1](./onboard/register-operator.md) with your **primary wallet**.
+   - Complete [Step 1](./onboard/register-operator.md) again with your **backup wallet**.
+   - This ensures both wallets are ready for activation.
 
    :::note
-   Only Step 1 (EigenLayer registration) is needed now. Steps 2-5 will be completed after the DIN contract is deployed on mainnet.
+   Begin with Step 1 (EigenLayer registration) to start the 17-day activation period. Complete Steps 2-5 while waiting for activation.
    :::
 
 ## Configuration steps
@@ -130,7 +132,7 @@ assets and accept slashing risk.
 
 - **Not creating a backup wallet**
 
-    _Fix_: Create and register **two** wallets with EigenLayer. If your primary wallet encounters issues during onboarding (e.g., transaction
+    _Fix_: Create and register **two** wallets with EigenLayer. If your primary wallet encounters issues during onboarding (for example, transaction
     failures, wrong configuration), having a backup wallet decreases the risk of wasting the 17-day activation period.
 
 - **Insufficient ETH for gas**

--- a/docs/avs/operator-onboarding/prerequisites.md
+++ b/docs/avs/operator-onboarding/prerequisites.md
@@ -41,12 +41,14 @@ Onboarding an operator on mainnet involves a 17-day activation period, so it's i
 
 ### Current strategies
 
-- stETH (Lido Staked ETH)
-- WETH (Wrapped ETH)
+DIN launched its mainnet AVS on November 17, 2025, with support for:
 
-:::note
-Additional strategies will be available after launch.
-:::
+- stETH (Lido Staked ETH)
+
+Additional strategies coming soon:
+
+- Native staked ETH
+- EIGEN token
 
 ## Technical requirements
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,81 +1,80 @@
 # Roadmap
 
-DIN is progressing through a carefully structured roadmap that gradually enhances its decentralization, scalability, and governance capabilities.
-This roadmap is divided into key phases, each designed to build on the last, ensuring a robust and resilient network.
+DIN progresses through a structured roadmap that enhances its decentralization, scalability, and governance capabilities.
+This roadmap divides into key phases, each building on the last to ensure a robust and resilient network.
 
-| Phase | Milestones | Description |
-| ----- | ---------- | ----------- |
-| Federated Phase (2024) | Joining DIN, processing transactions | Alpha customers (Infura, MetaMask) route API traffic and seed developer calls; providers meet performance thresholds and handle transactions, with payments managed through traditional invoicing. |
-| Progressive Decentralization (2024-2025) | DIN as an AVS, decentralized transaction processing, DIN Payments Layer 3, DIN Foundation and DAO, incentivized testnet | Early stage integration of economic security and staking/slashing through DIN as an AVS; providers gain routing flexibility beyond Infura; payments move to Layer 3 on-chain protocol; DIN Foundation oversees shared services and governance transitions to DAO-driven decision-making. |
-| Full Decentralization (2025-2026) | Permissionless onboarding, advanced payments, and DAO-managed innovation fund | DIN becomes fully permissionless, enabling automated service level agreement enforcement, dynamic pricing, cross-protocol staking, and DAO-led growth initiatives, establishing DIN as a decentralized, community-driven infrastructure for web3. |
+| Phase | Status | Milestones | Description |
+| ----- | ------ | ---------- | ----------- |
+| Federated phase | Completed (2024) | Joining DIN, processing transactions | Alpha customers (Infura, MetaMask) route API traffic and seed developer calls; providers meet performance thresholds and handle transactions, with payments managed through traditional invoicing. |
+| Progressive decentralization | In progress (2024-2025) | DIN as an AVS (launched November 17, 2025), decentralized transaction processing, DIN Payments Layer 3 (planned), DIN Foundation and DAO (planned), incentivized testnet (completed) | Integration of economic security and staking/slashing through DIN as an AVS; providers gain routing flexibility beyond Infura; payments will move to Layer 3 onchain protocol; DIN Foundation will oversee shared services and governance will transition to DAO-driven decision-making. |
+| Full decentralization | Planned (2025-2026) | Permissionless onboarding, advanced payments, and DAO-managed innovation fund | DIN becomes fully permissionless, enabling automated service level agreement enforcement, dynamic pricing, cross-protocol staking, and DAO-led growth initiatives, establishing DIN as a decentralized, community-driven infrastructure for web3. |
 
-## Federated Phase
+## Federated phase
 
-The Federated Phase is the foundational stage of DIN, where the network's initial components are deployed, tested, and refined in a controlled environment with trusted alpha customers.
-This phase focuses on establishing DIN's basic operational capabilities, ensuring service reliability, and verifying economic viability before fully opening the network.
+The federated phase is the foundational stage of DIN, where the network's initial components were deployed, tested, and refined in a controlled environment with trusted alpha customers.
+This phase focused on establishing DIN's basic operational capabilities, ensuring service reliability, and verifying economic viability before fully opening the network.
 
 ### Joining DIN
 
 - **Acceptance criteria and minimum performance thresholds** - During this phase,
-  DIN implements strict entry requirements for node providers and watchers,
-  ensuring that each participant meets predefined performance standards.
-  Providers must demonstrate compliance with service-level agreements covering metrics
+  DIN implemented strict entry requirements for node providers and watchers,
+  ensuring that each participant met predefined performance standards.
+  Providers demonstrated compliance with service-level agreements covering metrics
   such as response freshness, data validity, and uptime.
 
-- **Assigned identities for DIN routing** - Each participant is assigned a unique identity, enabling seamless routing of developer API requests to the appropriate node providers.
-  This identity management system lays the groundwork for effective transaction processing and tracking, setting clear accountability for each operator within the network.
+- **Assigned identities for DIN routing** - Each participant was assigned a unique identity, enabling seamless routing of developer API requests to the appropriate node providers.
+  This identity management system laid the groundwork for effective transaction processing and tracking, setting clear accountability for each operator within the network.
 
 ### Processing transactions for DIN
 
-- **Transaction routing from alpha customers** - Infura and MetaMask generate developer API traffic, which is routed through DIN provider nodes.
-  This federated setup enables DIN to validate its routing efficiency, latency benchmarks, and load-balancing algorithms under real-world conditions.
+- **Transaction routing from alpha customers** - Infura and MetaMask generated developer API traffic, which was routed through DIN provider nodes.
+  This federated setup enabled DIN to validate its routing efficiency, latency benchmarks, and load-balancing algorithms under real-world conditions.
 
 - **Traditional invoicing and payment validation** - In this phase,
-  payments from alpha customers to node providers are handled through traditional invoicing,
+  payments from alpha customers to node providers were handled through traditional invoicing,
   allowing DIN to test and refine its financial tracking and reward distribution processes.
-  This traditional invoicing approach provides DIN with critical insights into payment workflows,
+  This traditional invoicing approach provided DIN with critical insights into payment workflows,
   helping to prepare the network for decentralized, onchain payment models in later phases.
 
-## Progressive Decentralization
+## Progressive decentralization
 
-In 2025, DIN will transition from its federated setup to a progressively decentralized network.
+DIN launched its mainnet AVS on November 17, 2025, transitioning from its federated setup to a progressively decentralized network.
 This phase introduces additional layers of decentralization,
 with expanded functionality for transaction routing, payments, and governance,
 marking the beginning of DIN's evolution towards a permissionless infrastructure.
-With inspiration, the Cosmos Hub introduced a modular approach to interoperability, allowing networks to expand and evolve through phased upgrades.
 
 ### DIN as an AVS
 
-The practical implementation of the network watcher has explored usage of DIN launching as an Autonomous Verifiable Service (AVS) on EigenLayer.
+DIN launched as an Autonomous Verifiable Service (AVS) on EigenLayer on November 17, 2025.
 EigenLayer's AVS model provides a robust framework for economic alignment and real-time performance enforcement.
-DIN has integrated new functionalities that streamline agent onboarding,
+DIN integrates functionalities that streamline agent onboarding,
 improve oversight via a watchtower,
 and establish a structured accountability model without launching a token that may have floating value.
 
-- **Onboarding components** - Ability for providers to stake and add their wallet identities to join the DIN Router Registry contracts
+- **Onboarding components** - Providers stake and add their wallet identities to join the DIN Router Registry contracts.
 
-- **Economic security service level agreements** - Watcher and AVS operator capabilities for staking, slashing, and challenging the onboarded node performance and reputation of entities in DIN.
+- **Economic security service level agreements** - Watchers and AVS operators use staking, slashing, and challenges to monitor onboarded node performance and reputation of entities in DIN.
 
-The DIN AVS system aims to deploy watchers with a dedicated "watcher node kit," which operates as both a monitoring tool and a user-friendly interface to the DIN network backend.
+The DIN AVS system deploys watchers with a dedicated "watcher node kit," which operates as both a monitoring tool and a user-friendly interface to the DIN network backend.
 Through the AVS interface, watchers access essential modules for onboarding DIN providers, viewing onboarding notes, tracking network status, and enforcing slashing protocols.
 
-Acting as operators on EigenLayer, DIN watchers not only monitor service accuracy and reliability but also uphold AVS-based slashing and staking rules for performance infractions.
+DIN watchers act as operators on EigenLayer and monitor service accuracy and reliability while upholding AVS-based slashing and staking rules for performance infractions.
 Watchers gather and analyze response data by running simulated requests to ensure adherence to service level agreements.
-Their results are then published on a public event stream, providing transparency and informing DIN's crypto-economic incentives.
+Watchers publish their results on a public event stream, providing transparency and informing DIN's crypto-economic incentives.
 By aligning with EigenLayer's AVS structure,
 DIN strengthens its validation processes,
 ensuring real-time accountability and economic security for all network participants.
 
 ### Decentralized traffic processing
 
-- **Provider-driven routing capabilities** - Providers in the DIN network will gain the ability to route service traffic through various web3 gateways, not limited to Infura.
-  This expanded functionality decentralizes the routing process, creating an open network where multiple web3 gateways can interact with DIN providers.
+- **Provider-driven routing capabilities** - Providers in the DIN network route service traffic through various web3 gateways, not limited to Infura.
+  This expanded functionality decentralizes the routing process, creating an open network where multiple web3 gateways interact with DIN providers.
 
-- **DIN Payments Layer 3 network** - DIN will implement an onchain payments layer on Linea as a Layer 3 to facilitate real-time, decentralized payments among DIN providers and web3 gateways.
+- **DIN Payments Layer 3 network** - DIN plans to implement an onchain payments layer on Linea as a Layer 3 to facilitate real-time, decentralized payments among DIN providers and web3 gateways.
   This payments layer will allow for seamless, automated transactions, eliminating the need for traditional invoicing and streamlining economic interactions within DIN.
   Operators will be compensated based on their service contributions, with payment records transparently available onchain.
 
-### DIN Foundation and governance
+### DIN foundation and governance
 
 - **Establishment of the DIN Foundation** - The DIN Foundation will be formed to oversee shared services,
   community initiatives, and technical upgrades,
@@ -85,45 +84,40 @@ ensuring real-time accountability and economic security for all network particip
 
 - **Decentralized governance and DAO** - The introduction of a DIN DAO will enable community-led governance,
   where stakeholders propose and vote on protocol upgrades, SLA adjustments, and economic policies.
-  Token holders who stake within the DAO gain voting rights,
+  Token holders who stake within the DAO will gain voting rights,
   empowering them to shape the future of DIN and ensuring that governance decisions reflect the collective interests of the network.
 
 ### Incentivized testnet as a mechanism design laboratory
 
-Incentivized testnets are invaluable for stress-testing decentralized infrastructure and optimizing network mechanics
-before mainnet deployment.
-The DIN Incentivized Testnet is a vital component of DIN's mechanism design,
-allowing the network to test, validate,
-and optimize its economic structures in a live, controlled environment.
-The testnet enables DIN to fine-tune its staking, slashing, reward,
-and governance mechanisms before mainnet deployment.
+DIN completed its incentivized testnet, which validated the network's economic structures and performance capabilities before mainnet launch on November 17, 2025.
+The testnet achieved a >99% success rate, median latency under 250ms, and served 7B+ monthly requests during pilot phases.
+DIN maintains a perpetual testnet environment for new operators to validate their infrastructure.
 
 #### Economic testing and reward calibration
 
-- **Staking and slashing simulations** - The incentivized testnet allows DIN to run simulations of staking
-  and slashing mechanisms,
-  identifying optimal thresholds for penalties and ensuring that the economic deterrents are effective
+- **Staking and slashing simulations** - The incentivized testnet validated staking and slashing mechanisms,
+  identifying optimal thresholds for penalties and ensuring that economic deterrents are effective
   without being overly punitive.
 
 - **Reward structure optimization** - By distributing rewards based on testnet performance,
   DIN collects data on the effectiveness of its incentive structures,
   including high-performance bonuses and routing efficiency rewards.
-  This feedback helps the DAO calibrate rewards to ensure they align with desired behaviors and network standards.
+  This feedback helps calibrate rewards to align with desired behaviors and network standards.
 
-- **DAO policy feedback** - Testnet participants are encouraged to provide feedback on the economic
+- **Policy feedback** - Testnet participants provided feedback on the economic
   and governance policies in place.
-  This input allows the DAO to make informed adjustments,
-  ensuring that the network's policies are fair, practical, and aligned with community expectations.
+  This input allows informed adjustments to network policies,
+  ensuring they are fair, practical, and aligned with community expectations.
 
 #### Participant onboarding and reputation building
 
 - **Early access to economic mechanisms** - Node providers, watchers,
-  and web3 gateways gain early access to DIN's staking, slashing, and reward systems through the testnet.
-  This experience allows them to adapt to DIN's operational standards and fine-tune their infrastructure,
+  and web3 gateways gained early access to DIN's staking, slashing, and reward systems through the testnet.
+  This experience allowed them to adapt to DIN's operational standards and fine-tune their infrastructure,
   reducing the learning curve for mainnet.
 
-- **Reputation establishment** - Participants who perform well on the incentivized testnet build a reputation
-  that can carry over to the mainnet,
+- **Reputation establishment** - Participants who performed well on the incentivized testnet built a reputation
+  that carries over to the mainnet,
   giving them a competitive edge in request routing and access to higher-tier rewards.
   This early reputation system encourages operators to establish themselves as reliable contributors
   to DIN's ecosystem.
@@ -132,12 +126,12 @@ and governance mechanisms before mainnet deployment.
 
 - **Performance data collection** - Real-time data on SLA compliance, request throughput,
   and operator availability from the testnet informs adjustments to the mainnet mechanism design.
-  The DAO reviews this data to refine parameters,
+  This data helps refine parameters,
   ensuring DIN's economic model supports scalability and network resilience.
 
-- **Iterative testing for robust mechanisms** - The testnet enables iterative testing of new policies
-  and mechanisms, allowing the DAO to make adjustments based on test outcomes.
-  This iterative process ensures that only well-tested mechanisms are deployed on mainnet,
+- **Iterative testing for robust mechanisms** - The testnet enabled iterative testing of new policies
+  and mechanisms, allowing adjustments based on test outcomes.
+  This iterative process ensured that only well-tested mechanisms are deployed on mainnet,
   reducing the likelihood of economic inefficiencies or security vulnerabilities.
 
 ## Full decentralization and governance-driven expansion


### PR DESCRIPTION
Updated roadmap content because DIN has launched as an AVS.
Used the press release to help identify the current status.
https://www.din.build/blog/din-avs-restaking-launch